### PR TITLE
Touch1200

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code has been converted from Python 2 to Python 3.
 The executable `nrfutil` has been renamed to `adafruit-nrfutil` to distinguish it from the
 original executable.
 
-This tool can be used used with the [Adafruit nRF52 Feather](https://www.adafruit.com/product/3406)
+This tool can be used with the [Adafruit nRF52 Feather](https://www.adafruit.com/product/3406)
 to flash firmware images onto the device using the simple serial port.
 
 This library is written for Python 3.5+. It is no longer Python 2 compatible!
@@ -35,12 +35,18 @@ $ pip3 install adafruit-nrfutil --user
 
 ## Installing from Source
 
-### OS X and Linux
+Use this method if you have issue installing with PyPi or want to modify the tool. First clone this repo and go into its folder.
+
+```
+$ git clone https://github.com/adafruit/Adafruit_nRF52_nrfutil.git
+$ cd Adafruit_nRF52_nrfutil
+```
+
+Note: following commands use `python3`, however if you are on Windows, you may need to change it to `python` since windows installation of python 3.x still uses the name python.exe
 
 To install in user space in your home directory:
 
 ```
-$ cd Adafruit_nRF52_nrfutil
 $ pip3 install -r requirements.txt
 $ python3 setup.py install --user
 ```
@@ -50,45 +56,28 @@ or is set to try to install in the system directories. In that case use the
 `--user` flag:
 
 ```
-$ cd Adafruit_nRF52_nrfutil
 $ pip3 install -r --user requirements.txt
 $ python3 setup.py install --user
 ```
 
 If you want to install in system directories (generally not recommended):
 ```
-$ cd Adafruit_nRF52_nrfutil
 $ sudo pip3 install -r requirements.txt
 $ sudo python3 setup.py install
 ```
 
-Note: When installing requirements if you encounter the message
-**Cannot uninstall 'six'. It is a distutils installed project ...**,
-you may need to add `--ignore-installed six` when running pip.
+### Create self-contained binary
 
-### Windows
-
-#### Option 1: Pre-Built Binary
-
-A pre-built 32-bit version of adafruit-nrfutil.exe is included as part of this repo in the
-`binaries/win32` folder. You can use this pre-built binary by adding it to your
-systems `$PATH` variable
-
-#### Option 2: Build nrfutil from Source
-
-Make sure that you have **Python 3.5** available on your system.
-
-To generate a self-contained Windows `.exe` version of the utility (Windows only),
-run these commands in a CMD window:
+To generate a self-contained executable binary of the utility (Windows and MacOS), run these commands:
 
 ```
 pip3 install pyinstaller
-cd Adafruit_nRF52_nrfuil
+cd Adafruit_nRF52_nrfutil
 pip3 install -r requirements.txt
 cd Adafruit_nRF52_nrfutil\nordicsemi
 pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
 ```
-You will find the .exe in `Adafruit_nRF52_nrfutil\nordicsemi\adafruit-nrfutil.exe`.
+You will find the .exe in `Adafruit_nRF52_nrfutil\nordicsemi\dist\adafruit-nrfutil` ( with `.exe` if you are on windows).
 Copy or move it elsewhere for your convenience, such as directory in your %PATH%.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ or is set to try to install in the system directories. In that case use the
 
 ```
 $ pip3 install -r --user requirements.txt
-$ python3 setup.py install --user
+$ python3 setup.py install
 ```
 
 If you want to install in system directories (generally not recommended):

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 and the `nordicsemi` library.
 
 This package is derived from the Nordic Semiconductor ASA package
-https://github.com/NordicSemiconductor/pc-nrfutil, version 0.5.3.
-THe code has been converted from Python 2 to Python 3.
+[pc-nrfutil](https://github.com/NordicSemiconductor/pc-nrfutil), version 0.5.3.
+The code has been converted from Python 2 to Python 3.
 
 The executable `nrfutil` has been renamed to `adafruit-nrfutil` to distinguish it from the
 original executable.
@@ -17,8 +17,23 @@ This library is written for Python 3.5+. It is no longer Python 2 compatible!
 
 # Installation
 
+## Prerequisites
+
+- Python3
+- pip3
+
 Run the following commands to make `adafruit-nrfutil` available from the command line
 or to development platforms like the Arduino IDE or CircuitPython:
+
+## Installing from PyPI
+
+This is recommended method, to install latest version
+
+```
+$ pip3 install adafruit-nrfutil --user
+```
+
+## Installing from Source
 
 ### OS X and Linux
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or to development platforms like the Arduino IDE or CircuitPython:
 This is recommended method, to install latest version
 
 ```
-$ pip3 install adafruit-nrfutil --user
+$ pip3 install --user adafruit-nrfutil
 ```
 
 ## Installing from Source
@@ -48,7 +48,7 @@ To install in user space in your home directory:
 
 ```
 $ pip3 install -r requirements.txt
-$ python3 setup.py install --user
+$ python3 setup.py install
 ```
 
 If you get permission errors when running `pip3 install`, your `pip3` is older

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -274,16 +274,21 @@ def update_progress(progress=0, done=False, log_message=""):
 @click.option('-sb', '--singlebank',
               help='Single band bootloader to skip firmware activating delay, default: Dual bank',
               type=click.BOOL,
+              default=False,
               is_flag=True)
+@click.option('-t', '--touch',
+              help='Open port with specified baud then close it, before uploading',
+              type=click.INT,
+              default=0)
 
-def serial(package, port, baudrate, flowcontrol, singlebank):
+def serial(package, port, baudrate, flowcontrol, singlebank, touch):
     """Program a device with bootloader that support serial DFU"""
-    serial_backend = DfuTransportSerial(port, baudrate, flowcontrol, singlebank)
+    serial_backend = DfuTransportSerial(port, baudrate, flowcontrol, singlebank, touch)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(package, dfu_transport=serial_backend)
 
-    click.echo("Upgrading target on {1} with DFU package {0}. Flow control is {2}, {3} bank mode"
-               .format(package, port, "enabled" if flowcontrol else "disabled", "Single" if singlebank else "Dual"))
+    click.echo("Upgrading target on {1} with DFU package {0}. Flow control is {2}, {3} bank, Touch {4}"
+               .format(package, port, "enabled" if flowcontrol else "disabled", "Single" if singlebank else "Dual", touch if touch > 0 else "disabled"))
 
     try:
         dfu.dfu_send_images()

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -30,4 +30,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "0.5.3.post8"
+NRFUTIL_VERSION = "0.5.3.post9"


### PR DESCRIPTION
add --touch option to
1. connect with specified baudrate
2. disconnect
3. proceed with uploading

Application firmware such as Arduino, Circuitpython used this as signal to reset to bootloader mode to remove the need to manual holding DFU button.

@dhalbert  I also update the readme a bit, feel free to change it.

Note: Please don't merge this right away, I am still testing with waiting timing for cross platform. This is for review so that we could merge it quickly later. 

