### PR TITLE
Freeze Click to 7.1.2 for now due to bugz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
     pyserial >= 2.7
-    click >= 5.1
+    click == 7.1.2
     ecdsa >= 0.13
     behave

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     include_package_data=False,
     install_requires=[
         "pyserial >= 2.7",
-        "click >= 5.1",
+        "click == 7.1.2",
         "ecdsa >= 0.13",
     ],
     tests_require=[


### PR DESCRIPTION
Click 8.0.0 just came out a few days ago and it's causing learn guide PRs to fail.