### PR TITLE
Fix for click 8.0.0

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -46,6 +46,7 @@ class nRFException(Exception):
 
 
 def int_as_text_to_int(value):
+    value = str(value)
     try:
         if value[:2].lower() == '0x':
             return int(value[2:], 16)
@@ -60,6 +61,7 @@ class BasedIntOrNoneParamType(click.ParamType):
     name = 'Int or None'
 
     def convert(self, value, param, ctx):
+        value = str(value)
         try:
             if value.lower() == 'none':
                 return 'none'

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -30,4 +30,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "0.5.3.post15"
+NRFUTIL_VERSION = "0.5.3.post16"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
     pyserial >= 2.7
-    click == 7.1.2
+    click >= 5.1
     ecdsa >= 0.13
     behave

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     include_package_data=False,
     install_requires=[
         "pyserial >= 2.7",
-        "click == 7.1.2",
+        "click >= 5.1",
         "ecdsa >= 0.13",
     ],
     tests_require=[


### PR DESCRIPTION
When click released version 8.0.0, it was passing in value as the raw value instead of a string like it did in 7.1.2. This should fix the issue by converting the value to a string explicitly regardless of the version.