### PR TITLE
Create self contained binaries for windows/macos when release

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -24,7 +24,8 @@ jobs:
         pip3 install -r requirements.txt
         cd nordicsemi
         pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
-        7z a -tzip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil.exe
+        cd dist
+        7z a -tzip ../../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip adafruit-nrfutil.exe
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
@@ -35,4 +36,36 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip
         asset_name: adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip
+        asset_content_type: application/zip
+
+  macOS:
+    runs-on: macos-latest
+
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Create binaries
+      run: |
+        pip3 install pyinstaller
+        pip3 install -r requirements.txt
+        cd nordicsemi
+        pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
+        cd dist
+        7z a -tzip ../../adafruit-nrfutil--${{ github.event.release.tag_name }}-macos.zip adafruit-nrfutil
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'release' }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: adafruit-nrfutil--${{ github.event.release.tag_name }}-macos.zip
+        asset_name: adafruit-nrfutil--${{ github.event.release.tag_name }}-macos.zip
         asset_content_type: application/zip

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,23 @@
+name: Relase Binaries
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+        
+    - name: Checkout code
+      uses: actions/checkout@v2
+      
+    - name: Create binaries
+      run: |
+        pip3 install pyinstaller
+        pip3 install -r requirements.txt
+        cd nordicsemi
+        pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,9 +1,12 @@
 name: Relase Binaries
 
-on: [push]
+on:
+  release:
+    types:
+      - created
 
 jobs:
-  build:
+  windows:
     runs-on: windows-latest
     
     steps:
@@ -21,3 +24,15 @@ jobs:
         pip3 install -r requirements.txt
         cd nordicsemi
         pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
+        zip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil/adafruit-nrfutil.exe
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'release' }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip
+        asset_name: adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip
+        asset_content_type: application/zip

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 install -r requirements.txt
         cd nordicsemi
         pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
-        7z a -tzip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil/adafruit-nrfutil.exe
+        7z a -tzip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil.exe
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 install -r requirements.txt
         cd nordicsemi
         pyinstaller __main__.py --onefile --clean --name adafruit-nrfutil
-        zip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil/adafruit-nrfutil.exe
+        7z a -tzip ../adafruit-nrfutil--${{ github.event.release.tag_name }}-win.zip dist/adafruit-nrfutil/adafruit-nrfutil.exe
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
previously windows and macos binaries is built manually on local machine (way before action ci is a thing). This PR adds ci workflow to generate binaries on those platform and upload as release assets as new version is released 