### PR TITLE
limit windows binaries to build with python 3.8 due to win7 compatible

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.8'
         
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
should fix https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/676, still waiting for user feedback