### PR TITLE
Fix test TestSigning::test_get_vk_pem

### DIFF
--- a/nordicsemi/dfu/tests/test_signing.py
+++ b/nordicsemi/dfu/tests/test_signing.py
@@ -152,4 +152,4 @@ class TestSinging(unittest.TestCase):
 
         vk_pem = signing.get_vk_pem().decode("ascii")
 
-        self.assertEqual(expected_vk_pem, vk_pem)
+        self.assertEqual(expected_vk_pem.replace('\n', ''), vk_pem.replace('\n', ''))


### PR DESCRIPTION
Newer versions of Python apparently changed how the PEM output is formatted, specifically where the line-breaks are placed within the base64-encoded PEM string. This would cause the test to fail. 

In order to be immune to formatting changes, I have stripped all newlines from the PEM strings in the offending test `TestSigning::test_get_vk_pem` .